### PR TITLE
Update intl dependency to ^0.20.2

### DIFF
--- a/flutterapp/pubspec.yaml
+++ b/flutterapp/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   dio: ^5.3.2
   flutter_secure_storage: ^9.0.0
   provider: ^6.1.1
-  intl: ^0.18.1
+  intl: ^0.20.2
   cached_network_image: ^3.3.0
   photo_view: ^0.14.0
   permission_handler: ^11.0.1


### PR DESCRIPTION
## Purpose
The user encountered a dependency resolution failure when running `flutter pub get`. The issue was caused by a version conflict where `flutter_localizations` from the Flutter SDK requires `intl 0.20.2`, but the project was pinned to `intl ^0.18.1`. This update resolves the dependency conflict to allow successful package installation.

## Code changes
- Updated `intl` dependency constraint from `^0.18.1` to `^0.20.2` in `pubspec.yaml`
- This change aligns with the Flutter SDK's requirement for `flutter_localizations`

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/12886d0ae09b406782cdccb9bc32ce4c/glow-realm)

👀 [Preview Link](https://12886d0ae09b406782cdccb9bc32ce4c-glow-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>12886d0ae09b406782cdccb9bc32ce4c</projectId>-->
<!--<branchName>glow-realm</branchName>-->